### PR TITLE
Adding Status Code to root level

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -454,6 +454,7 @@ extension AWSClient {
         switch responseBody {
         case .json(let dictionary):
             outputDict = dictionary
+            outputDict["StatusCode"] = Int32(response.statusCode)
             
         case .xml(let node):
             let str = XMLNodeSerializer(node: node).serializeToJSON()


### PR DESCRIPTION
When dealing with JSON, the StatusCode object is not reported and returns nil in higher level APIs.


Create a function in AWS Lambda

**My_Function**
```
'use strict';

exports.handler = (event, context, callback) => {
    console.log('Received event: %s', JSON.stringify(event, null, 2));
    vat object = event;
    event.another = "Test";
    event.object = { "hello": "world" };
    callback(null, object);
};
```

Using this AWS CLI command with the `input.txt`, you will get the response `outputfile.txt` below.

**AWS CLI lambda command**
```
aws lambda invoke \
--invocation-type RequestResponse \
--function-name My_Function \
--region us-east-1 \
--payload file://~/input.txt \
outputfile.txt
```

**input.txt**
```
{
    "action": "start"
}
```

**Command Line Output**
```
{
    "StatusCode": 200
}
```

**outputfile.txt**
```
{
    "action": "start",
    "another": "Test",
    "object": {
        "hello": "world"
    }
}
```

Using the Lambda portion of the SDK, `.statusCode = nil`. We expect `.statusCode = 200`.
