### PR TITLE
Improve external representation and object mapping

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -383,8 +383,12 @@ extension AWSClient {
         }
         
         for (key, value) in response.headers {
-            if let param = Output.headerParams.filter({ $0.key.lowercased() == key.description.lowercased() }).first {
-                outputDict[param.key] = value
+            if let index = Output.headerParams.index(where: { $0.key.lowercased() == key.description.lowercased() }) {
+                if let number = Double(value) {
+                    outputDict[Output.headerParams[index].key] = number.truncatingRemainder(dividingBy: 1) == 0 ? Int(number) : number
+                } else {
+                    outputDict[Output.headerParams[index].key] = value
+                }
             }
         }
         

--- a/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
@@ -9,7 +9,31 @@
 import Foundation
 
 private func dquote(_ str: String) -> String {
+    if str.isEmpty {
+        return ""
+    }
+    
+    if str.first == "\"" && str.last == "\"" {
+        return str
+    }
+    
     return "\"\(str)\""
+}
+
+private func formatAsJSONValue(_ str: String) -> String {
+    if let number = Double(str) {
+        if number.truncatingRemainder(dividingBy: 1) == 0 {
+            return Int(number).description
+        } else {
+            return number.description
+        }
+    } else if ["false", "true"].contains(where: { $0 == str.lowercased() }) {
+        return str
+    } else if str == "null" {
+        return str
+    } else {
+        return dquote(str)
+    }
 }
 
 public class XMLNodeSerializer {
@@ -63,12 +87,12 @@ public class XMLNodeSerializer {
                 jsonStr += dquote(node.elementName) + ":"
                 
                 if node.hasArrayValue() {
-                    jsonStr += "[" +  node.values.map({ dquote($0) }).joined(separator: ",") + "]"
+                    jsonStr += "[" +  node.values.map({ formatAsJSONValue($0) }).joined(separator: ",") + "]"
                     if nodeTree.count-index > 1 { jsonStr+="," }
                 }
                 
                 if node.hasSingleValue() {
-                    jsonStr += dquote(node.values[0])
+                    jsonStr += formatAsJSONValue(node.values[0])
                     if nodeTree.count-index > 1 { jsonStr+="," }
                 }
                 
@@ -89,7 +113,7 @@ public class XMLNodeSerializer {
                         if nodes.isStructedArray() {
                             jsonStr += (nodes.map({ "{" + _serialize(nodeTree: $0.children) + "}"  }).joined(separator: ","))
                         } else {
-                            jsonStr += nodes.flatMap({ $0.values }).map({ dquote($0) }).joined(separator: ",")
+                            jsonStr += nodes.flatMap({ $0.values }).map({ formatAsJSONValue($0) }).joined(separator: ",")
                         }
                         jsonStr += "]"
                         if newChildren.count > 0 { jsonStr += "," }

--- a/Sources/AWSSDKSwiftCore/XML/XMLParser.swift
+++ b/Sources/AWSSDKSwiftCore/XML/XMLParser.swift
@@ -9,12 +9,14 @@
 import Foundation
 
 public enum XML2ParserError: Error {
-    case unknownError
+    case failedToParse(Data)
 }
 
 public class XML2Parser: NSObject, XMLParserDelegate {
     
     private let parser: XMLParser
+    
+    private let data: Data
     
     private var error: Error?
     
@@ -27,6 +29,7 @@ public class XML2Parser: NSObject, XMLParserDelegate {
     private var currentNodeIsArray = false
     
     public init(data: Data) {
+        self.data = data
         self.parser = XMLParser(data: data)
         super.init()
         self.parser.delegate = self
@@ -37,7 +40,7 @@ public class XML2Parser: NSObject, XMLParserDelegate {
         if let nodeTree = nodeTree {
             return nodeTree
         }
-        throw XML2ParserError.unknownError
+        throw XML2ParserError.failedToParse(data)
     }
     
     public func parser(_ parser: XMLParser, foundCharacters string: String) {


### PR DESCRIPTION
This PR relates https://github.com/noppoMan/aws-sdk-swift/issues/61.

* If the response type has `payloadPath`, the responded body data should be handled as buffer not external representation.
* More robust mapping process between external representation and object. It's necessary for successfully decoding with Swift's Decoder
  * Convert the value in XML to JSON native type if the value is meaningful for JSON. (e.g, "null" => null, "3.1" => Double: 3.1)
  * Convert the header value to number if it can cast Double. (e.g "1" => Int: 1, "1.1" => Double: 1.1)
