### PR TITLE
We should always lowercase true and false when converting JSON

### DIFF
--- a/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
@@ -28,7 +28,7 @@ private func formatAsJSONValue(_ str: String) -> String {
             return number.description
         }
     } else if ["false", "true"].contains(where: { $0 == str.lowercased() }) {
-        return str
+        return str.lowercased()
     } else if str == "null" {
         return str
     } else {

--- a/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
@@ -70,6 +70,16 @@ class SerializersTests: XCTestCase {
         XCTAssertEqual(dict.count, jsonObect.count)
     }
     
+    func testLowercasedBoolean() {
+        let node = try! XML2Parser(data: "<A>True</A>".data).parse()
+        let str = XMLNodeSerializer(node: node).serializeToJSON()
+        XCTAssertEqual(str, "{\"A\":true}")
+
+        let outputDict = try! JSONSerialization.jsonObject(with: str.data(using: .utf8)!, options: []) as? [String: Any] ?? [:]
+        XCTAssertEqual(outputDict["A"] as? Bool, true)
+        XCTAssertEqual(outputDict.count, 1)
+    }
+
     func testSerializeToFlatDictionary() {
         let data = try! JSONEncoder().encode(A())
         let dict = try! JSONSerializer().serializeToFlatDictionary(data)
@@ -85,6 +95,7 @@ class SerializersTests: XCTestCase {
         return [
             ("testSerializeToXML", testSerializeToXML),
             ("testSerializeToDictionaryAndJSON", testSerializeToDictionaryAndJSON),
+            ("testLowercasedBoolean", testLowercasedBoolean),
             ("testSerializeToFlatDictionary", testSerializeToFlatDictionary)
         ]
     }


### PR DESCRIPTION
My calls to [`DescribeAutoScalingGroups`](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DescribeAutoScalingGroups.html) returned a value of `False`. This caused a crash via `JSONDecoder`, which could not handle the input (and was expecting a lowercased `false`).

This change now defensively handles the case where we receive a capitalized boolean value back from the API.